### PR TITLE
Add Redis client and pool

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,3 +4,8 @@ target_link_libraries(echo muduo_core ${LIBS})
 add_executable(client Client.cpp)
 target_link_libraries(client muduo_core ${LIBS})
 
+
+add_executable(redis_example RedisExample.cpp ../storage/cache/RedisClient.cpp ../storage/cache/RedisPool.cpp)
+target_include_directories(redis_example PRIVATE ${CMAKE_SOURCE_DIR}/storage/cache)
+target_link_libraries(redis_example hiredis ${LIBS})
+

--- a/examples/RedisExample.cpp
+++ b/examples/RedisExample.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+
+#include "RedisClient.h"
+#include "RedisPool.h"
+
+int main() {
+    // Create pool with single connection for demonstration.
+    RedisPool pool("127.0.0.1", 6379, 1);
+    auto client = pool.GetClient();
+    if (!client) {
+        std::cerr << "No redis client available" << std::endl;
+        return -1;
+    }
+    client->Set("hello", "world");
+    std::string value;
+    if (client->Get("hello", value)) {
+        std::cout << "hello => " << value << std::endl;
+    }
+    client->Del("hello");
+    return 0;
+}
+

--- a/storage/cache/RedisClient.cpp
+++ b/storage/cache/RedisClient.cpp
@@ -1,0 +1,97 @@
+#include "RedisClient.h"
+
+#include <iostream>
+
+RedisClient::RedisClient(const std::string& host, int port,
+                         const std::string& password,
+                         const struct timeval& timeout)
+    : context_(nullptr), host_(host), port_(port), password_(password), timeout_(timeout) {}
+
+RedisClient::~RedisClient() {
+    if (context_) {
+        redisFree(context_);
+        context_ = nullptr;
+    }
+}
+
+bool RedisClient::Connect() {
+    if (context_) {
+        redisFree(context_);
+        context_ = nullptr;
+    }
+
+    context_ = redisConnectWithTimeout(host_.c_str(), port_, timeout_);
+    if (!context_ || context_->err) {
+        if (context_) {
+            std::cerr << "Redis connect error: " << context_->errstr << std::endl;
+            redisFree(context_);
+            context_ = nullptr;
+        } else {
+            std::cerr << "Redis connect error." << std::endl;
+        }
+        return false;
+    }
+    redisSetTimeout(context_, timeout_);
+    if (!password_.empty()) {
+        redisReply* reply = (redisReply*)redisCommand(context_, "AUTH %s", password_.c_str());
+        if (!reply || reply->type == REDIS_REPLY_ERROR) {
+            if (reply) {
+                std::cerr << "Redis auth error: " << reply->str << std::endl;
+                freeReplyObject(reply);
+            }
+            redisFree(context_);
+            context_ = nullptr;
+            return false;
+        }
+        freeReplyObject(reply);
+    }
+    return true;
+}
+
+bool RedisClient::EnsureConnected() {
+    if (context_ && context_->err == 0) {
+        return true;
+    }
+    return Connect();
+}
+
+bool RedisClient::Get(const std::string& key, std::string& value) {
+    if (!EnsureConnected()) return false;
+    redisReply* reply = (redisReply*)redisCommand(context_, "GET %s", key.c_str());
+    if (!reply) {
+        std::cerr << "Redis GET command failed" << std::endl;
+        return false;
+    }
+    bool ok = false;
+    if (reply->type == REDIS_REPLY_STRING) {
+        value.assign(reply->str, reply->len);
+        ok = true;
+    }
+    freeReplyObject(reply);
+    return ok;
+}
+
+bool RedisClient::Set(const std::string& key, const std::string& value) {
+    if (!EnsureConnected()) return false;
+    redisReply* reply = (redisReply*)redisCommand(context_, "SET %s %s", key.c_str(), value.c_str());
+    if (!reply) {
+        std::cerr << "Redis SET command failed" << std::endl;
+        return false;
+    }
+    bool ok = reply->type == REDIS_REPLY_STATUS && strcasecmp(reply->str, "OK") == 0;
+    freeReplyObject(reply);
+    return ok;
+}
+
+bool RedisClient::Del(const std::string& key) {
+    if (!EnsureConnected()) return false;
+    redisReply* reply = (redisReply*)redisCommand(context_, "DEL %s", key.c_str());
+    if (!reply) {
+        std::cerr << "Redis DEL command failed" << std::endl;
+        return false;
+    }
+    bool ok = reply->type == REDIS_REPLY_INTEGER && reply->integer > 0;
+    freeReplyObject(reply);
+    return ok;
+}
+

--- a/storage/cache/RedisClient.h
+++ b/storage/cache/RedisClient.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <sys/time.h>
+#include <hiredis/hiredis.h>
+
+// Simple Redis client managing a single connection.
+// Provides basic Get/Set/Del operations with optional authentication
+// and timeout configuration.
+class RedisClient {
+public:
+    RedisClient(const std::string& host, int port,
+                const std::string& password = "",
+                const struct timeval& timeout = {1, 500000});
+    ~RedisClient();
+
+    // Connect to redis server. Returns true on success.
+    bool Connect();
+
+    bool Get(const std::string& key, std::string& value);
+    bool Set(const std::string& key, const std::string& value);
+    bool Del(const std::string& key);
+
+    bool IsConnected() const { return context_ != nullptr; }
+
+private:
+    bool EnsureConnected();
+
+    redisContext* context_;
+    std::string host_;
+    int port_;
+    std::string password_;
+    struct timeval timeout_;
+};
+

--- a/storage/cache/RedisPool.cpp
+++ b/storage/cache/RedisPool.cpp
@@ -1,0 +1,46 @@
+#include "RedisPool.h"
+
+#include <iostream>
+
+RedisPool::RedisPool(const std::string& host, int port, size_t pool_size,
+                     const std::string& password, int timeout_ms)
+    : host_(host), port_(port), password_(password) {
+    timeout_.tv_sec = timeout_ms / 1000;
+    timeout_.tv_usec = (timeout_ms % 1000) * 1000;
+    for (size_t i = 0; i < pool_size; ++i) {
+        auto* client = new RedisClient(host_, port_, password_, timeout_);
+        if (client->Connect()) {
+            clients_.push(client);
+        } else {
+            delete client;
+            std::cerr << "Failed to create redis connection" << std::endl;
+        }
+    }
+}
+
+RedisPool::~RedisPool() {
+    while (!clients_.empty()) {
+        delete clients_.front();
+        clients_.pop();
+    }
+}
+
+std::shared_ptr<RedisClient> RedisPool::GetClient() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cond_.wait(lock, [this] { return !clients_.empty(); });
+    RedisClient* client = clients_.front();
+    clients_.pop();
+    lock.unlock();
+    // Ensure connection alive
+    if (!client->IsConnected()) {
+        client->Connect();
+    }
+    return std::shared_ptr<RedisClient>(client, [this](RedisClient* c) { this->Release(c); });
+}
+
+void RedisPool::Release(RedisClient* client) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    clients_.push(client);
+    cond_.notify_one();
+}
+

--- a/storage/cache/RedisPool.h
+++ b/storage/cache/RedisPool.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <string>
+
+#include "RedisClient.h"
+
+// Simple thread-safe pool for Redis connections.
+class RedisPool {
+public:
+    RedisPool(const std::string& host, int port, size_t pool_size,
+              const std::string& password = "", int timeout_ms = 1000);
+    ~RedisPool();
+
+    // Acquire a client from pool. Returned shared_ptr will automatically
+    // return client back to pool when destroyed.
+    std::shared_ptr<RedisClient> GetClient();
+
+private:
+    void Release(RedisClient* client);
+
+    std::string host_;
+    int port_;
+    std::string password_;
+    struct timeval timeout_;
+
+    std::mutex mutex_;
+    std::condition_variable cond_;
+    std::queue<RedisClient*> clients_;
+};
+


### PR DESCRIPTION
## Summary
- add RedisClient wrapper with basic Get/Set/Del support, authentication and timeouts
- add RedisPool for connection reuse
- provide RedisExample demonstrating usage

## Testing
- `cmake -S . -B build`
- `cmake --build build --target redis_example` *(fails: fatal error: hiredis/hiredis.h: No such file or directory)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d030114483278b89fa2b59ccaafd