### PR TITLE
Add HTTP interceptor chain and router

### DIFF
--- a/framework/router/Router.h
+++ b/framework/router/Router.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "http/HttpRequest.h"
+#include "http/HttpResponse.h"
+
+// Base class for HTTP request interceptors.
+class Interceptor {
+public:
+    using Next = std::function<void()>;
+    virtual ~Interceptor() = default;
+    virtual void Handle(HttpRequest& req, HttpResponse& res, Next next) = 0;
+};
+
+// Maintains a list of interceptors and executes them sequentially.
+class InterceptorChain {
+public:
+    void addInterceptor(const std::shared_ptr<Interceptor>& interceptor) {
+        interceptors_.push_back(interceptor);
+    }
+
+    void handle(HttpRequest& req, HttpResponse& res,
+                const std::function<void(HttpRequest&, HttpResponse&)>& finalHandler) {
+        std::function<void(size_t)> dispatch = [&](size_t index) {
+            if (index < interceptors_.size()) {
+                interceptors_[index]->Handle(req, res, [&, index]() { dispatch(index + 1); });
+            } else {
+                finalHandler(req, res);
+            }
+        };
+        dispatch(0);
+    }
+
+private:
+    std::vector<std::shared_ptr<Interceptor>> interceptors_;
+};
+
+// Simple path based router with support for interceptors.
+class Router {
+public:
+    using Handler = std::function<void(HttpRequest&, HttpResponse&)>;
+
+    void addRoute(const std::string& path, const Handler& handler) {
+        routes_[path] = handler;
+    }
+
+    void addInterceptor(const std::shared_ptr<Interceptor>& interceptor) {
+        chain_.addInterceptor(interceptor);
+    }
+
+    void handle(HttpRequest& req, HttpResponse& res) {
+        auto it = routes_.find(req.path());
+        Handler handler;
+        if (it != routes_.end()) {
+            handler = it->second;
+        } else {
+            handler = [](HttpRequest& /*unused*/, HttpResponse& response) {
+                response.setStatusCode(HttpResponse::k404NotFound);
+                response.setStatusMessage("Not Found");
+            };
+        }
+        chain_.handle(req, res, handler);
+    }
+
+private:
+    std::unordered_map<std::string, Handler> routes_;
+    InterceptorChain chain_;
+};
+

--- a/modules/http/HttpServer.h
+++ b/modules/http/HttpServer.h
@@ -10,7 +10,7 @@
 
 class HttpServer {
 public:
-    using HttpCallback = std::function<void(const HttpRequest&, HttpResponse*)>;
+    using HttpCallback = std::function<void(HttpRequest&, HttpResponse&)>;
 
     HttpServer(EventLoop* loop, const InetAddress& listenAddr, const std::string& name, TcpServer::Option option = TcpServer::kNoReusePort);
 
@@ -22,7 +22,7 @@ public:
 private:
     void onConnection(const TcpConnectionPtr& conn);
     void onMessage(const TcpConnectionPtr& conn, Buffer* buf, TimeStamp receiveTime);
-    void onRequest(const TcpConnectionPtr& conn, const HttpRequest& req);
+    void onRequest(const TcpConnectionPtr& conn, HttpRequest& req);
 
     TcpServer server_;
     HttpCallback httpCallback_;

--- a/modules/http/src/HttpServer.cpp
+++ b/modules/http/src/HttpServer.cpp
@@ -37,14 +37,14 @@ void HttpServer::onMessage(const TcpConnectionPtr& conn, Buffer* buf, TimeStamp 
     }
 }
 
-void HttpServer::onRequest(const TcpConnectionPtr& conn, const HttpRequest& req) {
+void HttpServer::onRequest(const TcpConnectionPtr& conn, HttpRequest& req) {
     bool close = false;
     if (req.getHeader("Connection") == "close" || (req.version() == HttpRequest::kHttp10 && req.getHeader("Connection") != "Keep-Alive")) {
         close = true;
     }
     HttpResponse response(close);
     if (httpCallback_) {
-        httpCallback_(req, &response);
+        httpCallback_(req, response);
     } else {
         response.setStatusCode(HttpResponse::k404NotFound);
         response.setStatusMessage("Not Found");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_executable(spsc_test SpscRingBufferTest.cpp)
 target_include_directories(spsc_test PRIVATE ${CMAKE_SOURCE_DIR}/framework/utils)
 
+add_executable(router_interceptor_test RouterInterceptorTest.cpp)
+target_include_directories(router_interceptor_test PRIVATE ${CMAKE_SOURCE_DIR}/framework ${CMAKE_SOURCE_DIR}/modules)
+target_link_libraries(router_interceptor_test muduo_http)
+

--- a/tests/RouterInterceptorTest.cpp
+++ b/tests/RouterInterceptorTest.cpp
@@ -1,0 +1,78 @@
+#include <cassert>
+#include <vector>
+#include <string>
+#include <iostream>
+
+#include "router/Router.h"
+
+class RecordingInterceptor : public Interceptor {
+public:
+    RecordingInterceptor(const std::string& name, std::vector<std::string>& log)
+        : name_(name), log_(log) {}
+
+    void Handle(HttpRequest& req, HttpResponse& res, Next next) override {
+        log_.push_back(name_);
+        next();
+    }
+private:
+    std::string name_;
+    std::vector<std::string>& log_;
+};
+
+class StopInterceptor : public Interceptor {
+public:
+    StopInterceptor(std::vector<std::string>& log) : log_(log) {}
+    void Handle(HttpRequest& req, HttpResponse& res, Next next) override {
+        log_.push_back("stop");
+        // Intentionally do not call next() to stop the chain
+    }
+private:
+    std::vector<std::string>& log_;
+};
+
+void TestOrder() {
+    Router router;
+    std::vector<std::string> log;
+    router.addInterceptor(std::make_shared<RecordingInterceptor>("A", log));
+    router.addInterceptor(std::make_shared<RecordingInterceptor>("B", log));
+    router.addRoute("/test", [&](HttpRequest& req, HttpResponse& res) {
+        log.push_back("handler");
+        res.setStatusCode(HttpResponse::k200Ok);
+    });
+
+    HttpRequest req;
+    const char* path = "/test";
+    req.setPath(path, path + 5);
+    HttpResponse res(false);
+    router.handle(req, res);
+
+    assert((log == std::vector<std::string>{"A", "B", "handler"}));
+}
+
+void TestShortCircuit() {
+    Router router;
+    std::vector<std::string> log;
+    router.addInterceptor(std::make_shared<RecordingInterceptor>("A", log));
+    router.addInterceptor(std::make_shared<StopInterceptor>(log));
+    router.addInterceptor(std::make_shared<RecordingInterceptor>("B", log));
+    router.addRoute("/test", [&](HttpRequest& req, HttpResponse& res) {
+        log.push_back("handler");
+        res.setStatusCode(HttpResponse::k200Ok);
+    });
+
+    HttpRequest req;
+    const char* path = "/test";
+    req.setPath(path, path + 5);
+    HttpResponse res(false);
+    router.handle(req, res);
+
+    assert((log == std::vector<std::string>{"A", "stop"}));
+}
+
+int main() {
+    TestOrder();
+    TestShortCircuit();
+    std::cout << "All router tests passed!" << std::endl;
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add generic Interceptor base class and InterceptorChain
- implement Router with support for interceptors
- switch HttpServer callback to use mutable request/response references
- add unit tests for interceptor order and short-circuiting

## Testing
- `cmake --build . --target router_interceptor_test spsc_test`
- `./tests/router_interceptor_test`
- `./tests/spsc_test`


------
https://chatgpt.com/codex/tasks/task_e_68c3d301a8b483278e12f57a0257f712