### PR TITLE
Add core component unit tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: cd build && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(muduo-core)
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED True)
 
+enable_testing()
+
 #链接必要的库
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 set(LIBS pthread)
@@ -13,5 +15,10 @@ set(LIBS pthread)
 #添加子目录
 add_subdirectory(core)
 add_subdirectory(modules)
-add_subdirectory(examples)
+
+option(BUILD_EXAMPLES "Build examples" OFF)
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
 add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,27 @@
+enable_testing()
+
 add_executable(spsc_test SpscRingBufferTest.cpp)
 target_include_directories(spsc_test PRIVATE ${CMAKE_SOURCE_DIR}/framework/utils)
+add_test(NAME spsc_test COMMAND spsc_test)
 
 add_executable(router_interceptor_test RouterInterceptorTest.cpp)
 target_include_directories(router_interceptor_test PRIVATE ${CMAKE_SOURCE_DIR}/framework ${CMAKE_SOURCE_DIR}/modules)
 target_link_libraries(router_interceptor_test muduo_http)
+add_test(NAME router_interceptor_test COMMAND router_interceptor_test)
 
+add_executable(http_server_test HttpServerTest.cpp)
+target_include_directories(http_server_test PRIVATE ${CMAKE_SOURCE_DIR}/tests/mocks ${CMAKE_SOURCE_DIR}/modules ${CMAKE_SOURCE_DIR}/core/include)
+add_test(NAME http_server_test COMMAND http_server_test)
+
+add_executable(router_test RouterTest.cpp)
+target_include_directories(router_test PRIVATE ${CMAKE_SOURCE_DIR}/framework ${CMAKE_SOURCE_DIR}/modules)
+target_link_libraries(router_test muduo_http)
+add_test(NAME router_test COMMAND router_test)
+
+add_executable(config_manager_test ConfigManagerTest.cpp)
+target_include_directories(config_manager_test PRIVATE ${CMAKE_SOURCE_DIR}/framework/utils)
+add_test(NAME config_manager_test COMMAND config_manager_test)
+
+add_executable(connection_pool_test ConnectionPoolTest.cpp)
+target_include_directories(connection_pool_test PRIVATE ${CMAKE_SOURCE_DIR}/tests/mocks ${CMAKE_SOURCE_DIR}/storage/db/ConnectionPool)
+add_test(NAME connection_pool_test COMMAND connection_pool_test)

--- a/tests/ConfigManagerTest.cpp
+++ b/tests/ConfigManagerTest.cpp
@@ -1,0 +1,23 @@
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include "ConfigManager.h"
+#include "ConfigManager.cpp"
+
+int main() {
+    const std::string filename = "test_config.json";
+    std::ofstream ofs(filename);
+    ofs << "{\n  \"port\": \"8080\",\n  \"debug\": \"true\",\n  \"pi\": \"3.14\"\n}";
+    ofs.close();
+
+    auto& cm = ConfigManager::Instance();
+    assert(cm.Load(filename));
+    assert(cm.GetInt("port") == 8080);
+    assert(cm.GetBool("debug"));
+    assert(cm.GetDouble("pi") == 3.14);
+    assert(cm.GetString("missing", "default") == "default");
+
+    std::remove(filename.c_str());
+    std::cout << "ConfigManagerTest passed" << std::endl;
+    return 0;
+}

--- a/tests/ConnectionPoolTest.cpp
+++ b/tests/ConnectionPoolTest.cpp
@@ -1,0 +1,25 @@
+#include <cassert>
+#include <iostream>
+#include "ConnectionPool.h"
+#include "ConnectionPool.cpp"
+#include "cppconn/driver.h"
+
+static sql::Driver mock_driver;
+sql::Driver* get_driver_instance() { return &mock_driver; }
+
+int main() {
+    DBConfig cfg;
+    cfg.database = "testdb";
+    cfg.pool_size = 1;
+    auto& pool = ConnectionPool::Instance();
+    pool.Init(cfg);
+    assert(mock_driver.connect_count == 1);
+    {
+        auto conn = pool.Acquire();
+        assert(conn);
+    }
+    auto conn2 = pool.Acquire();
+    assert(conn2);
+    std::cout << "ConnectionPoolTest passed" << std::endl;
+    return 0;
+}

--- a/tests/HttpServerTest.cpp
+++ b/tests/HttpServerTest.cpp
@@ -1,0 +1,48 @@
+#include <cassert>
+#include <iostream>
+#include "Buffer.h"
+#include "TimeStamp.h"
+#include "TcpServer.h"
+#include "http/HttpContext.h"
+#include "http/HttpResponse.h"
+
+// expose private methods of HttpServer only
+#define private public
+#include "http/HttpServer.h"
+#undef private
+#include "http/src/HttpRequest.cpp"
+#include "http/src/HttpResponse.cpp"
+#include "http/src/HttpContext.cpp"
+#include "http/src/HttpServer.cpp"
+
+int main() {
+    EventLoop loop;
+    InetAddress addr("127.0.0.1", 8080);
+
+    // Test default 404 when no callback is set
+    HttpServer server(&loop, addr, "test");
+    TcpConnectionPtr conn1 = std::make_shared<TcpConnection>();
+    HttpRequest req1;
+    const char* path1 = "/";
+    req1.setPath(path1, path1 + 1);
+    server.onRequest(conn1, req1);
+    assert(conn1->sent.find("404 Not Found") != std::string::npos);
+    assert(conn1->shutdownCalled);
+
+    // Test custom callback returning 200
+    HttpServer server2(&loop, addr, "test2");
+    server2.setHttpCallback([](HttpRequest& req, HttpResponse& res) {
+        res.setStatusCode(HttpResponse::k200Ok);
+        res.setStatusMessage("OK");
+    });
+    TcpConnectionPtr conn2 = std::make_shared<TcpConnection>();
+    HttpRequest req2;
+    const char* path2 = "/hello";
+    req2.setPath(path2, path2 + 6);
+    server2.onRequest(conn2, req2);
+    assert(conn2->sent.find("200 OK") != std::string::npos);
+    assert(!conn2->shutdownCalled);
+
+    std::cout << "HttpServerTest passed" << std::endl;
+    return 0;
+}

--- a/tests/RouterTest.cpp
+++ b/tests/RouterTest.cpp
@@ -1,0 +1,27 @@
+#include <cassert>
+#include <iostream>
+
+#define private public
+#include "router/Router.h"
+#undef private
+
+int main() {
+    Router router;
+    router.addRoute("/hi", [](HttpRequest& req, HttpResponse& res) {
+        res.setStatusCode(HttpResponse::k200Ok);
+        res.setStatusMessage("OK");
+    });
+
+    HttpRequest req1; const char* p1 = "/hi"; req1.setPath(p1, p1 + 3);
+    HttpResponse res1(false);
+    router.handle(req1, res1);
+    assert(res1.statusCode_ == HttpResponse::k200Ok);
+
+    HttpRequest req2; const char* p2 = "/none"; req2.setPath(p2, p2 + 5);
+    HttpResponse res2(false);
+    router.handle(req2, res2);
+    assert(res2.statusCode_ == HttpResponse::k404NotFound);
+
+    std::cout << "RouterTest passed" << std::endl;
+    return 0;
+}

--- a/tests/mocks/TcpServer.h
+++ b/tests/mocks/TcpServer.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <functional>
+#include <memory>
+#include <string>
+#include "Buffer.h"
+#include "TimeStamp.h"
+
+class EventLoop {};
+class InetAddress {
+public:
+    InetAddress(const std::string& ip, uint16_t port) {}
+};
+
+class TcpConnection {
+public:
+    std::string sent;
+    bool shutdownCalled{false};
+    bool connected() const { return true; }
+    void send(const std::string& data) { sent += data; }
+    void shutdown() { shutdownCalled = true; }
+};
+
+using TcpConnectionPtr = std::shared_ptr<TcpConnection>;
+using ConnectionCallback = std::function<void(const TcpConnectionPtr&)>;
+using MessageCallback = std::function<void(const TcpConnectionPtr&, Buffer*, TimeStamp)>;
+
+class TcpServer {
+public:
+    enum Option { kNoReusePort };
+    TcpServer(EventLoop*, const InetAddress&, const std::string&, Option option = kNoReusePort) {}
+    void setConnectionCallback(const ConnectionCallback& cb) { connectionCallback_ = cb; }
+    void setMessageCallback(const MessageCallback& cb) { messageCallback_ = cb; }
+    void setThreadNum(int) {}
+    void start() {}
+private:
+    ConnectionCallback connectionCallback_;
+    MessageCallback messageCallback_;
+};

--- a/tests/mocks/cppconn/connection.h
+++ b/tests/mocks/cppconn/connection.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+
+namespace sql {
+class Connection {
+public:
+    void setSchema(const std::string& schema) { schema_ = schema; }
+    std::string schema_;
+};
+}

--- a/tests/mocks/cppconn/driver.h
+++ b/tests/mocks/cppconn/driver.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <string>
+#include "connection.h"
+
+namespace sql {
+class Driver {
+public:
+    Driver() : connect_count(0) {}
+    Connection* connect(const std::string& url, const std::string& user, const std::string& password) {
+        ++connect_count;
+        last_url = url; last_user = user; last_password = password;
+        return new Connection();
+    }
+    int connect_count;
+    std::string last_url, last_user, last_password;
+};
+}
+
+sql::Driver* get_driver_instance();

--- a/tests/mocks/cppconn/exception.h
+++ b/tests/mocks/cppconn/exception.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <exception>
+
+namespace sql {
+class SQLException : public std::exception {
+public:
+    const char* what() const noexcept override { return "sql exception"; }
+};
+}


### PR DESCRIPTION
## Summary
- add unit tests for HttpServer, Router, ConfigManager and ConnectionPool using mock network/DB objects
- wire tests into CMake/CTest and enable optional build of examples
- configure GitHub Actions workflow to build and run tests

## Testing
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c3d80306c0832788f34328aa16329f