### PR TITLE
feat: add method-aware router with parameterized paths

### DIFF
--- a/modules/http/CMakeLists.txt
+++ b/modules/http/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 add_library(muduo_http SHARED ${SRC_FILES})
-target_include_directories(muduo_http PUBLIC ${CMAKE_SOURCE_DIR}/core/include ${CMAKE_SOURCE_DIR}/modules)
+target_include_directories(muduo_http PUBLIC ${CMAKE_SOURCE_DIR}/core/include ${CMAKE_SOURCE_DIR}/modules ${CMAKE_SOURCE_DIR}/framework)
 target_link_libraries(muduo_http PUBLIC muduo_core)
 

--- a/modules/http/HttpRequest.h
+++ b/modules/http/HttpRequest.h
@@ -26,11 +26,13 @@ public:
     Version version() const { return version_; }
 
     bool setMethod(const char* start, const char* end);
-    Method method() const { return method_; }
+    // Convenience accessors for routing
+    std::string method() const { return methodString(); }
     const char* methodString() const;
-
-    void setPath(const char* start, const char* end) { path_.assign(start, end); }
     const std::string& path() const { return path_; }
+
+    Method methodEnum() const { return method_; }
+    void setPath(const char* start, const char* end) { path_.assign(start, end); }
 
     void setQuery(const char* start, const char* end) { query_.assign(start, end); }
     const std::string& query() const { return query_; }

--- a/modules/http/HttpServer.h
+++ b/modules/http/HttpServer.h
@@ -7,14 +7,13 @@
 #include "TcpServer.h"
 #include "http/HttpContext.h"
 #include "http/HttpResponse.h"
+#include "router/Router.h"
 
 class HttpServer {
 public:
-    using HttpCallback = std::function<void(HttpRequest&, HttpResponse&)>;
-
     HttpServer(EventLoop* loop, const InetAddress& listenAddr, const std::string& name, TcpServer::Option option = TcpServer::kNoReusePort);
 
-    void setHttpCallback(const HttpCallback& cb) { httpCallback_ = cb; }
+    Router& router() { return router_; }
 
     void setThreadNum(int numThreads) { server_.setThreadNum(numThreads); }
     void start();
@@ -25,6 +24,6 @@ private:
     void onRequest(const TcpConnectionPtr& conn, HttpRequest& req);
 
     TcpServer server_;
-    HttpCallback httpCallback_;
+    Router router_;
     std::unordered_map<TcpConnection*, HttpContext> contexts_;
 };

--- a/modules/http/src/HttpServer.cpp
+++ b/modules/http/src/HttpServer.cpp
@@ -43,13 +43,7 @@ void HttpServer::onRequest(const TcpConnectionPtr& conn, HttpRequest& req) {
         close = true;
     }
     HttpResponse response(close);
-    if (httpCallback_) {
-        httpCallback_(req, response);
-    } else {
-        response.setStatusCode(HttpResponse::k404NotFound);
-        response.setStatusMessage("Not Found");
-        response.setCloseConnection(true);
-    }
+    router_.handle(req, response);
     Buffer buf;
     response.appendToBuffer(&buf);
     conn->send(buf.retrieveAllAsString());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,3 +5,7 @@ add_executable(router_interceptor_test RouterInterceptorTest.cpp)
 target_include_directories(router_interceptor_test PRIVATE ${CMAKE_SOURCE_DIR}/framework ${CMAKE_SOURCE_DIR}/modules)
 target_link_libraries(router_interceptor_test muduo_http)
 
+add_executable(router_route_test RouterRouteTest.cpp)
+target_include_directories(router_route_test PRIVATE ${CMAKE_SOURCE_DIR}/framework ${CMAKE_SOURCE_DIR}/modules ${CMAKE_SOURCE_DIR}/core/include)
+target_link_libraries(router_route_test muduo_http)
+

--- a/tests/RouterInterceptorTest.cpp
+++ b/tests/RouterInterceptorTest.cpp
@@ -35,7 +35,7 @@ void TestOrder() {
     std::vector<std::string> log;
     router.addInterceptor(std::make_shared<RecordingInterceptor>("A", log));
     router.addInterceptor(std::make_shared<RecordingInterceptor>("B", log));
-    router.addRoute("/test", [&](HttpRequest& req, HttpResponse& res) {
+    router.addRoute("GET", "/test", [&](HttpRequest& req, HttpResponse& res) {
         log.push_back("handler");
         res.setStatusCode(HttpResponse::k200Ok);
     });
@@ -43,6 +43,8 @@ void TestOrder() {
     HttpRequest req;
     const char* path = "/test";
     req.setPath(path, path + 5);
+    const char* m = "GET";
+    req.setMethod(m, m + 3);
     HttpResponse res(false);
     router.handle(req, res);
 
@@ -55,7 +57,7 @@ void TestShortCircuit() {
     router.addInterceptor(std::make_shared<RecordingInterceptor>("A", log));
     router.addInterceptor(std::make_shared<StopInterceptor>(log));
     router.addInterceptor(std::make_shared<RecordingInterceptor>("B", log));
-    router.addRoute("/test", [&](HttpRequest& req, HttpResponse& res) {
+    router.addRoute("GET", "/test", [&](HttpRequest& req, HttpResponse& res) {
         log.push_back("handler");
         res.setStatusCode(HttpResponse::k200Ok);
     });
@@ -63,6 +65,8 @@ void TestShortCircuit() {
     HttpRequest req;
     const char* path = "/test";
     req.setPath(path, path + 5);
+    const char* m = "GET";
+    req.setMethod(m, m + 3);
     HttpResponse res(false);
     router.handle(req, res);
 

--- a/tests/RouterRouteTest.cpp
+++ b/tests/RouterRouteTest.cpp
@@ -1,0 +1,78 @@
+#include <cassert>
+#include <iostream>
+#include <string>
+
+#include "Buffer.h"
+#include "router/Router.h"
+
+void TestMethodRouting() {
+    Router router;
+    int getHit = 0;
+    int postHit = 0;
+    router.addRoute("GET", "/get", [&](HttpRequest& req, HttpResponse& res) {
+        getHit = 1;
+        res.setStatusCode(HttpResponse::k200Ok);
+    });
+    router.addRoute("POST", "/post", [&](HttpRequest& req, HttpResponse& res) {
+        postHit = 1;
+        res.setStatusCode(HttpResponse::k200Ok);
+    });
+
+    HttpRequest req1;
+    const char* m1 = "GET";
+    req1.setMethod(m1, m1 + 3);
+    const char* p1 = "/get";
+    req1.setPath(p1, p1 + 4);
+    HttpResponse res1(false);
+    router.handle(req1, res1);
+    assert(getHit == 1 && postHit == 0);
+
+    HttpRequest req2;
+    const char* m2 = "POST";
+    req2.setMethod(m2, m2 + 4);
+    const char* p2 = "/post";
+    req2.setPath(p2, p2 + 5);
+    HttpResponse res2(false);
+    router.handle(req2, res2);
+    assert(getHit == 1 && postHit == 1);
+}
+
+void TestDynamicParam() {
+    Router router;
+    int hit = 0;
+    router.addRoute("GET", "/users/:id", [&](HttpRequest& req, HttpResponse& res) {
+        hit = 1;
+        res.setStatusCode(HttpResponse::k200Ok);
+    });
+    HttpRequest req;
+    const char* m = "GET";
+    req.setMethod(m, m + 3);
+    const char* p = "/users/123";
+    req.setPath(p, p + 10);
+    HttpResponse res(false);
+    router.handle(req, res);
+    assert(hit == 1);
+}
+
+void TestNotFound() {
+    Router router;
+    HttpRequest req;
+    const char* m = "GET";
+    req.setMethod(m, m + 3);
+    const char* p = "/unknown";
+    req.setPath(p, p + 8);
+    HttpResponse res(false);
+    router.handle(req, res);
+    Buffer buf;
+    res.appendToBuffer(&buf);
+    std::string output = buf.retrieveAllAsString();
+    assert(output.find("404") != std::string::npos);
+}
+
+int main() {
+    TestMethodRouting();
+    TestDynamicParam();
+    TestNotFound();
+    std::cout << "All router route tests passed!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- support HTTP method and parameterized path routing
- expose HttpRequest method and path for routing
- integrate Router into HttpServer
- add tests for method routing, parameters, and 404

## Testing
- `cmake --build . --target router_interceptor_test router_route_test`
- `./tests/router_interceptor_test && ./tests/router_route_test`


------
https://chatgpt.com/codex/tasks/task_e_68c3d7f3ff1083278757a77ebb55545b