### PR TITLE
Fix build and test failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ project(muduo-core)
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED True)
 
+# Expose headers from third_party (e.g. nlohmann/json)
+include_directories(${PROJECT_SOURCE_DIR}/third_party)
+
 enable_testing()
 
 #链接必要的库

--- a/modules/http/HttpRequest.h
+++ b/modules/http/HttpRequest.h
@@ -64,4 +64,5 @@ private:
     std::map<std::string, std::string> headers_;
     std::string body_;
     nlohmann::json json_;
+    std::shared_ptr<Session> session_;
 };

--- a/modules/http/HttpServer.h
+++ b/modules/http/HttpServer.h
@@ -11,12 +11,19 @@
 
 class HttpServer {
 public:
+    using HttpCallback = std::function<void(HttpRequest&, HttpResponse&)>;
+
     HttpServer(EventLoop* loop, const InetAddress& listenAddr, const std::string& name, TcpServer::Option option = TcpServer::kNoReusePort);
 
     Router& router() { return router_; }
 
     void setThreadNum(int numThreads) { server_.setThreadNum(numThreads); }
     void start();
+
+    void setHttpCallback(const HttpCallback& cb) { httpCallback_ = cb; }
+
+    // Expose request handling for tests
+    void handleRequestForTest(const TcpConnectionPtr& conn, HttpRequest& req) { onRequest(conn, req); }
 
 private:
     void onConnection(const TcpConnectionPtr& conn);
@@ -26,4 +33,5 @@ private:
     TcpServer server_;
     Router router_;
     std::unordered_map<TcpConnection*, HttpContext> contexts_;
+    HttpCallback httpCallback_;
 };

--- a/modules/http/src/HttpServer.cpp
+++ b/modules/http/src/HttpServer.cpp
@@ -43,7 +43,11 @@ void HttpServer::onRequest(const TcpConnectionPtr& conn, HttpRequest& req) {
         close = true;
     }
     HttpResponse response(close);
-    router_.handle(req, response);
+    if (httpCallback_) {
+        httpCallback_(req, response);
+    } else {
+        router_.handle(req, response);
+    }
     Buffer buf;
     response.appendToBuffer(&buf);
     conn->send(buf.retrieveAllAsString());

--- a/tests/AuthRoleInterceptorTest.cpp
+++ b/tests/AuthRoleInterceptorTest.cpp
@@ -21,7 +21,7 @@ static void InitRouter(Router& router, const RouterConfig& cfg) {
     if (cfg.enableRole) {
         router.addInterceptor(std::make_shared<RoleInterceptor>(std::unordered_set<std::string>{"admin"}));
     }
-    router.addRoute("/secure", [](HttpRequest& req, HttpResponse& res) {
+    router.addRoute("GET", "/secure", [](HttpRequest& req, HttpResponse& res) {
         res.setStatusCode(HttpResponse::k200Ok);
     });
 }
@@ -30,6 +30,7 @@ static HttpRequest BuildRequest(const std::vector<std::pair<std::string, std::st
     HttpRequest req;
     const char* path = "/secure";
     req.setPath(path, path + strlen(path));
+    const char* m = "GET"; req.setMethod(m, m+3);
     for (const auto& h : headers) {
         std::string line = h.first + ": " + h.second;
         req.addHeader(line.c_str(), line.c_str() + h.first.size(), line.c_str() + line.size());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(router_interceptor_test muduo_http)
 add_test(NAME router_interceptor_test COMMAND router_interceptor_test)
 
 add_executable(http_server_test HttpServerTest.cpp)
-target_include_directories(http_server_test PRIVATE ${CMAKE_SOURCE_DIR}/tests/mocks ${CMAKE_SOURCE_DIR}/modules ${CMAKE_SOURCE_DIR}/core/include)
+target_include_directories(http_server_test PRIVATE ${CMAKE_SOURCE_DIR}/tests/mocks ${CMAKE_SOURCE_DIR}/modules ${CMAKE_SOURCE_DIR}/core/include ${CMAKE_SOURCE_DIR}/framework ${CMAKE_SOURCE_DIR}/framework/utils)
 add_test(NAME http_server_test COMMAND http_server_test)
 
 add_executable(router_test RouterTest.cpp)
@@ -20,14 +20,16 @@ add_test(NAME router_test COMMAND router_test)
 
 add_executable(config_manager_test ConfigManagerTest.cpp)
 target_include_directories(config_manager_test PRIVATE ${CMAKE_SOURCE_DIR}/framework/utils)
+target_link_libraries(config_manager_test yaml-cpp)
 add_test(NAME config_manager_test COMMAND config_manager_test)
 
 add_executable(auth_role_interceptor_test AuthRoleInterceptorTest.cpp)
 target_include_directories(auth_role_interceptor_test PRIVATE ${CMAKE_SOURCE_DIR}/framework ${CMAKE_SOURCE_DIR}/modules)
 target_link_libraries(auth_role_interceptor_test muduo_http)
 
-add_executable(connection_pool_test ConnectionPoolTest.cpp)
-target_include_directories(connection_pool_test PRIVATE ${CMAKE_SOURCE_DIR}/tests/mocks ${CMAKE_SOURCE_DIR}/storage/db/ConnectionPool)
+add_executable(connection_pool_test ConnectionPoolTest.cpp ../framework/utils/ConfigManager.cpp)
+target_include_directories(connection_pool_test PRIVATE ${CMAKE_SOURCE_DIR}/tests/mocks ${CMAKE_SOURCE_DIR}/storage/db/ConnectionPool ${CMAKE_SOURCE_DIR}/framework/utils)
+target_link_libraries(connection_pool_test yaml-cpp)
 add_test(NAME connection_pool_test COMMAND connection_pool_test)
 
 

--- a/tests/ConfigManagerTest.cpp
+++ b/tests/ConfigManagerTest.cpp
@@ -7,7 +7,7 @@
 int main() {
     const std::string filename = "test_config.json";
     std::ofstream ofs(filename);
-    ofs << "{\n  \"port\": \"8080\",\n  \"debug\": \"true\",\n  \"pi\": \"3.14\"\n}";
+    ofs << "{\n  \"port\": 8080,\n  \"debug\": true,\n  \"pi\": 3.14\n}";
     ofs.close();
 
     auto& cm = ConfigManager::Instance();

--- a/tests/HttpServerTest.cpp
+++ b/tests/HttpServerTest.cpp
@@ -6,10 +6,8 @@
 #include "http/HttpContext.h"
 #include "http/HttpResponse.h"
 
-// expose private methods of HttpServer only
-#define private public
+// include server after headers
 #include "http/HttpServer.h"
-#undef private
 #include "http/src/HttpRequest.cpp"
 #include "http/src/HttpResponse.cpp"
 #include "http/src/HttpContext.cpp"
@@ -25,7 +23,9 @@ int main() {
     HttpRequest req1;
     const char* path1 = "/";
     req1.setPath(path1, path1 + 1);
-    server.onRequest(conn1, req1);
+    const char* m = "GET"; req1.setMethod(m, m+3);
+    req1.setVersion(HttpRequest::kHttp10);
+    server.handleRequestForTest(conn1, req1);
     assert(conn1->sent.find("404 Not Found") != std::string::npos);
     assert(conn1->shutdownCalled);
 
@@ -39,7 +39,9 @@ int main() {
     HttpRequest req2;
     const char* path2 = "/hello";
     req2.setPath(path2, path2 + 6);
-    server2.onRequest(conn2, req2);
+    req2.setMethod(m, m+3);
+    req2.setVersion(HttpRequest::kHttp11);
+    server2.handleRequestForTest(conn2, req2);
     assert(conn2->sent.find("200 OK") != std::string::npos);
     assert(!conn2->shutdownCalled);
 

--- a/tests/RouterTest.cpp
+++ b/tests/RouterTest.cpp
@@ -1,26 +1,28 @@
 #include <cassert>
 #include <iostream>
 
-#define private public
 #include "router/Router.h"
-#undef private
 
 int main() {
     Router router;
-    router.addRoute("/hi", [](HttpRequest& req, HttpResponse& res) {
+    router.addRoute("GET", "/hi", [](HttpRequest& req, HttpResponse& res) {
         res.setStatusCode(HttpResponse::k200Ok);
         res.setStatusMessage("OK");
     });
 
     HttpRequest req1; const char* p1 = "/hi"; req1.setPath(p1, p1 + 3);
+    const char* m = "GET"; req1.setMethod(m, m+3);
+    req1.setVersion(HttpRequest::kHttp10);
     HttpResponse res1(false);
     router.handle(req1, res1);
-    assert(res1.statusCode_ == HttpResponse::k200Ok);
+    assert(res1.statusCode() == HttpResponse::k200Ok);
 
     HttpRequest req2; const char* p2 = "/none"; req2.setPath(p2, p2 + 5);
+    req2.setMethod(m, m+3);
+    req2.setVersion(HttpRequest::kHttp10);
     HttpResponse res2(false);
     router.handle(req2, res2);
-    assert(res2.statusCode_ == HttpResponse::k404NotFound);
+    assert(res2.statusCode() == HttpResponse::k404NotFound);
 
     std::cout << "RouterTest passed" << std::endl;
     return 0;

--- a/tests/SessionTest.cpp
+++ b/tests/SessionTest.cpp
@@ -10,7 +10,7 @@ void TestSessionLifecycle() {
     Router router;
     auto store = std::make_shared<MemorySessionStore>();
     router.addInterceptor(std::make_shared<SessionInterceptor>(store, 1));
-    router.addRoute("/test", [](HttpRequest& req, HttpResponse& res) {
+    router.addRoute("GET", "/test", [](HttpRequest& req, HttpResponse& res) {
         auto session = req.getSession();
         std::string count = session->get("count");
         if (count.empty())
@@ -24,6 +24,7 @@ void TestSessionLifecycle() {
     HttpRequest req;
     const char* path = "/test";
     req.setPath(path, path + 5);
+    const char* m = "GET"; req.setMethod(m, m+3);
     HttpResponse res(false);
     router.handle(req, res);
     auto sid = req.getSession()->id();
@@ -31,6 +32,7 @@ void TestSessionLifecycle() {
 
     HttpRequest req2;
     req2.setPath(path, path + 5);
+    req2.setMethod(m, m+3);
     req2.setHeader("Cookie", "SESSIONID=" + sid);
     HttpResponse res2(false);
     router.handle(req2, res2);
@@ -40,6 +42,7 @@ void TestSessionLifecycle() {
 
     HttpRequest req3;
     req3.setPath(path, path + 5);
+    req3.setMethod(m, m+3);
     req3.setHeader("Cookie", "SESSIONID=" + sid);
     HttpResponse res3(false);
     router.handle(req3, res3);


### PR DESCRIPTION
## Summary
- add third_party headers to CMake build and expose JSON/YAML deps to tests
- extend HttpServer/HttpRequest with session and HTTP callback utilities
- update tests for new Router API and configuration parsing

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c3dfb5169083278aaf63dbf6ac873d