### PR TITLE
Add default GET route overload and update controllers

### DIFF
--- a/src/app/comment/CommentController.h
+++ b/src/app/comment/CommentController.h
@@ -17,7 +17,7 @@ public:
             res.setBody(body);
         });
 
-        router.addRoute("/comment/create", [service, this](HttpRequest& req, HttpResponse& res) {
+        router.addRoute("POST", "/comment/create", [service, this](HttpRequest& req, HttpResponse& res) {
             auto params = parseQuery(req.query());
             auto it = params.find("text");
             if (it != params.end()) {
@@ -48,7 +48,7 @@ public:
             }
         });
 
-        router.addRoute("/comment/update", [service, this](HttpRequest& req, HttpResponse& res) {
+        router.addRoute("POST", "/comment/update", [service, this](HttpRequest& req, HttpResponse& res) {
             auto params = parseQuery(req.query());
             auto itId = params.find("id");
             auto itText = params.find("text");
@@ -66,7 +66,7 @@ public:
             }
         });
 
-        router.addRoute("/comment/delete", [service, this](HttpRequest& req, HttpResponse& res) {
+        router.addRoute("POST", "/comment/delete", [service, this](HttpRequest& req, HttpResponse& res) {
             auto params = parseQuery(req.query());
             auto it = params.find("id");
             if (it != params.end()) {

--- a/src/app/post/PostController.h
+++ b/src/app/post/PostController.h
@@ -17,7 +17,7 @@ public:
             res.setBody(body);
         });
 
-        router.addRoute("/post/create", [service, this](HttpRequest& req, HttpResponse& res) {
+        router.addRoute("POST", "/post/create", [service, this](HttpRequest& req, HttpResponse& res) {
             auto params = parseQuery(req.query());
             auto itTitle = params.find("title");
             auto itContent = params.find("content");
@@ -49,7 +49,7 @@ public:
             }
         });
 
-        router.addRoute("/post/update", [service, this](HttpRequest& req, HttpResponse& res) {
+        router.addRoute("POST", "/post/update", [service, this](HttpRequest& req, HttpResponse& res) {
             auto params = parseQuery(req.query());
             auto itId = params.find("id");
             auto itTitle = params.find("title");
@@ -68,7 +68,7 @@ public:
             }
         });
 
-        router.addRoute("/post/delete", [service, this](HttpRequest& req, HttpResponse& res) {
+        router.addRoute("POST", "/post/delete", [service, this](HttpRequest& req, HttpResponse& res) {
             auto params = parseQuery(req.query());
             auto it = params.find("id");
             if (it != params.end()) {

--- a/src/app/user/UserController.h
+++ b/src/app/user/UserController.h
@@ -17,7 +17,7 @@ public:
             res.setBody(body);
         });
 
-        router.addRoute("/user/create", [service, this](HttpRequest& req, HttpResponse& res) {
+        router.addRoute("POST", "/user/create", [service, this](HttpRequest& req, HttpResponse& res) {
             auto params = parseQuery(req.query());
             auto it = params.find("name");
             if (it != params.end()) {
@@ -48,7 +48,7 @@ public:
             }
         });
 
-        router.addRoute("/user/update", [service, this](HttpRequest& req, HttpResponse& res) {
+        router.addRoute("POST", "/user/update", [service, this](HttpRequest& req, HttpResponse& res) {
             auto params = parseQuery(req.query());
             auto itId = params.find("id");
             auto itName = params.find("name");
@@ -66,7 +66,7 @@ public:
             }
         });
 
-        router.addRoute("/user/delete", [service, this](HttpRequest& req, HttpResponse& res) {
+        router.addRoute("POST", "/user/delete", [service, this](HttpRequest& req, HttpResponse& res) {
             auto params = parseQuery(req.query());
             auto it = params.find("id");
             if (it != params.end()) {

--- a/src/framework/router/Router.h
+++ b/src/framework/router/Router.h
@@ -54,6 +54,10 @@ public:
         routes_.push_back(std::move(r));
     }
 
+    void addRoute(const std::string& path, const Handler& handler) {
+        addRoute("GET", path, handler);
+    }
+
     void addInterceptor(const std::shared_ptr<Interceptor>& interceptor) {
         chain_.addInterceptor(interceptor);
     }


### PR DESCRIPTION
## Summary
- add addRoute overload defaulting to GET in Router
- specify POST for create/update/delete routes in app controllers

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c4bb8171d483278d43c3a75e96640c